### PR TITLE
Fixed #2 Uncaught TypeError: $(...).gantt is not a function

### DIFF
--- a/web_gantt/views/web_gantt.xml
+++ b/web_gantt/views/web_gantt.xml
@@ -3,6 +3,9 @@
   <data>
     <template id="assets_backend" name="web_gantt assets" inherit_id="web.assets_backend">
       <xpath expr="." position="inside">
+        <link rel="stylesheet" href="/web_gantt/static/lib/css/style.css"/>
+
+        <script type="text/javascript" src="/web_gantt/static/lib/js/jquery.fn.gantt.js"></script>
         <script type="text/javascript" src="/web_gantt/static/src/js/gantt.js"></script>
       </xpath>
     </template>


### PR DESCRIPTION
web_gantt into Odoo 9
- Fixed #2 Uncaught TypeError: $(...).gantt is not a function
